### PR TITLE
MalariaSummaryReport: Add control to use true density

### DIFF
--- a/docs/emod/software-report-malaria-summary.rst
+++ b/docs/emod/software-report-malaria-summary.rst
@@ -30,7 +30,8 @@ To generate this report, the following parameters must be configured in the cust
     **Parasitemia_Bins**, float, -3.40E+38, 3.40E+38, "[50,500,5000,50000,FLT_MAX]", "Parasitemia Bins to aggregate within and report.  A value greater than or equal to zero in the first bin indicates that the uninfected people should be added to this bin.  The values must be in ascending order."
     **Infectiousness_Bins**, float, -3.40E+38, 3.40E+38, "[20,40,60,80,100]", Infectiousness bins to aggregate within and report.
     **Individual_Property_Filter**, string, NA, NA, (empty string), "The individual 'property:value' to filter on. The default of an empty string means the report is not filtered. For example: 'Risk:High'."
-
+    **Use_True_Density_Vs_Threshold**, boolean, 0, 1, 0, "If set to true, the true parasite/gametocyte density will be used instead of the microscopy measurement for the following channels: 'PfPR_2to10', 'PfPR by Age Bin', 'Pf Gametocyte Prevalence by Age Bin', and 'Mean Log Parasite Density by Age Bin'.  The true density will be compared to thresholds: config.Report_Detection_Threshold_True_Parasite_Density and MalariaSummaryReport.Detection_Threshold_True_Gametocyte_Density.  If false, then BLOOD_SMEAR_PARASITES/BLOOD_SMEAR_GAMETOCYTES measurements are used (have uncertainty in the measurement).  The parasite measurement is compared against a threshold of zero and the gametocyte measurement a threshold of 0.02."
+    **Detection_Threshold_True_Gametocyte_Density**, float, 0, 3.40E+38, 0, "Used when 'Use_True_Density_Vs_Threshold' is true.  The true gametocyte density is compared against this threshold.  It impacts the 'Pf Gametocyte Prevalence by Age Bin' channel."
 
 
 .. code-block:: json
@@ -42,6 +43,7 @@ To generate this report, the following parameters must be configured in the cust
                 "Filename_Suffix": "Node1",
                 "Start_Day": 365,
                 "End_Day": 465,
+                "Use_True_Density_Vs_Threshold" : 0,
                 "Node_IDs_Of_Interest": [ 1 ],
                 "Must_Have_IP_Key_Value": "Risk:LOW",
                 "Must_Have_Intervention": "UsageDependentBednet"
@@ -127,7 +129,7 @@ The following statistics are collected:
 
     Time Of Report, "Each entry is the final day of the reporting interval, in days."
     Annual EIR, "The average Entomological Inoculation Rate (EIR) per year over the reporting interval."
-    PfPR_2to10, "The fraction of individuals whose age is 2 < age < 10 that would have been detected with the BLOOD_SMEAR_PARASITES diagnostic type of MalariaDiagnostic where the sensitivity is **Report_Parasites_Smear_Sensitivity** and the detection threshold is **Report_Detection_Threshold_Blood_Smear_Parasites**."
+    PfPR_2to10, "The fraction of individuals whose age is 2 < age < 10 that would have been detected with the BLOOD_SMEAR_PARASITES diagnostic type of MalariaDiagnostic where the sensitivity is **Report_Parasites_Smear_Sensitivity** and the detection threshold is zero.  Please note that his measurement includes some random noise.  If **Use_True_Density_Vs_Threshold** is set to true (1), then true parasite density is compared against the **Report_Detection_Threshold_True_Parasite_Density** value."
     No Infection Streak, The maximum number of days without an infection during the interval.
     Fraction Days Under 1pct Infected, The percentage of days during the interval in which the percentage of infected individuals was less than 1%.
 
@@ -142,9 +144,9 @@ Age Bin.
     :header: Parameter, Description
     :widths: 8, 20
 
-    PfPR by Age Bin, "The fraction of individuals in this age bin that would have been detected using the BLOOD_SMEAR_PARASITES diagnostic type of the MalariaDiagnostic intervention where the sensitivity is **Report_Parasites_Smear_Sensitivity** and the detection threshold is **Report_Detection_Threshold_Blood_Smear_Parasites.**"
-    pf Gametocyte Prevalence by Age Bin, "The fraction of individuals in this age bin that would have been detected using the BLOOD_SMEAR_GAMETOCYTES diagnostic type of the MalariaDiagnostic intervention where the sensitivity is **Report_Gametocyte_Smear_Sensitivity** and the detection threshold is **Report_Detection_Threshold_Blood_Smear_Gametocytes**."
-    Mean Log Parasite Density by Age Bin, The average Log10 parasite density of the population for that age bin based on the count of parasites using the BLOOD_SMEAR_PARASITES diagnostic type of MalariaDiagnostic where the sensitivity is **Report_Parasites_Smear_Sensitivity**.
+    PfPR by Age Bin, "The fraction of individuals in this age bin that would have been detected using the BLOOD_SMEAR_PARASITES diagnostic type of the MalariaDiagnostic intervention where the sensitivity is **Report_Parasites_Smear_Sensitivity** and the detection threshold is zero.  Please note that his measurement includes some random noise.  If **Use_True_Density_Vs_Threshold** is set to true (1), then true parasite density is compared against the **Report_Detection_Threshold_True_Parasite_Density** value."    
+    pf Gametocyte Prevalence by Age Bin, "The fraction of individuals in this age bin that would have been detected using the BLOOD_SMEAR_GAMETOCYTES diagnostic type of the MalariaDiagnostic intervention where the sensitivity is **Report_Gametocyte_Smear_Sensitivity** and the detection threshold is 0.02.  Please note that his measurement includes some random noise.  If **Use_True_Density_Vs_Threshold** is set to true (1), then true gametocyte density is compared against the **Detection_Threshold_True_Gametocyte_Density** value."    
+    Mean Log Parasite Density by Age Bin, "The average Log10 parasite density of the population for that age bin based on the count of parasites using the BLOOD_SMEAR_PARASITES diagnostic type of MalariaDiagnostic where the sensitivity is **Report_Parasites_Smear_Sensitivity**.  Please note that his measurement includes some random noise.  If **Use_True_Density_Vs_Threshold** is set to true (1), then Log10 is taken of the true parasite density.
     New Infections by Age Bin, "The number of new infections during the reporting interval for each age bin."
     Annual Clinical Incidence by Age Bin, "The number of new clinical symptoms per person per year.  This channel is controlled by the **Clinical_Fever_Threshold_Low** and **Clinical_Fever_Threshold_High** parameters.  The amount that an individual’s fever is above normal must be greater than both of these values to be considered clinical.  This can also be influenced by the **Min_Days_Between_Clinical_Incidents** parameter."
     Annual Severe Incidence by Age Bin, "The number of new severe symptoms per person per year.  An individual is considered to be a severe case if the combined probability of anemia, parasite density, and fever is greater than a uniform random number.  This combined probability is the combination of sigmoid using the following parameters: **Anemia_Severe_Threshold** and **Anemia_Severe_Inverse_Width**, **Parasite_Severe_Threshold** and **Parasite_Severe_Inverse_Width**, **Fever_Severe_Threshold** and **Fever_Severe_Inverse_Width**."
@@ -167,8 +169,8 @@ Parasitemia Bins, and Age Bins.
     :header: Parameter, Description
     :widths: 8, 20
 
-    PfPR by Parasitemia and Age Bin, "The fraction of individuals whose parasite density and age fall into this bin. The sum of the people whose true parasite density in the PfPRBin and age bin divided by the total number of people in the age bin."
-    PfPR by Gametocytemia and Age Bin, The fraction of individuals whose gametocyte density and age fall into this gametocyte bin.
+    PfPR by Parasitemia and Age Bin, "The fraction of individuals whose parasite density and age fall into this bin. The sum of the people whose true parasite density in the PfPRBin and age bin divided by the total number of people in the age bin.  Please note that people with zero parasitemia (i.e. only gametocytes) are counted in the bin that includes zero."
+    PfPR by Gametocytemia and Age Bin, "The fraction of individuals whose gametocyte density and age fall into this gametocyte bin.  Please note that people with zero gametocytes are counted in the bin that includes zero."
     Smeared PfPR by Parasitemia and Age Bin, "The fraction of individuals in this age bin whose true parasite density when smeared by CountPositiveSlideFields falls into this parasitemia bin."
     Smeared PfPR by Gametocytemia and Age Bin, "The fraction of individuals in this age bin whose true gametocyte density when smeared by CountPositiveSlideFields falls into this gametocyte bin."
     Smeared True PfPR by Parasitemia and Age Bin, "The fraction of individuals in this age bin whose true parasite density when smeared by NASBADensityWithUncertainty falls into this parasitemia bin."

--- a/emodpy_malaria/reporters/builtin.py
+++ b/emodpy_malaria/reporters/builtin.py
@@ -232,6 +232,8 @@ def add_malaria_summary_report(task, manifest,
                                reporting_interval: float = 365,
                                must_have_ip_key_value: str = "",
                                must_have_intervention: str = "",
+                               use_true_density: bool = False,
+                               gametocyte_detection_threshold: float = 0.0,
                                age_bins: list = None,
                                infectiousness_bins: list = None,
                                max_number_reports: int = 100,
@@ -253,6 +255,16 @@ def add_malaria_summary_report(task, manifest,
             means don't look at IPs (individual properties)
         must_have_intervention: the name of the an intervention that the person must have in order to be included.
             Empty string means don't look at the interventions
+        use_true_density: If set to true, the true parasite/gametocyte density will be used instead of the microscopy 
+            measurement for the following channels: 'PfPR_2to10', 'PfPR by Age Bin', 'Pf Gametocyte Prevalence by Age Bin',
+            and 'Mean Log Parasite Density by Age Bin'.  The true density will be compared to thresholds:
+            config.Report_Detection_Threshold_True_Parasite_Density and 'gametocyte_detection_threshold'
+            (MalariaSummaryReport.Detection_Threshold_True_Gametocyte_Density).  If false, then 
+            BLOOD_SMEAR_PARASITES/BLOOD_SMEAR_GAMETOCYTES measurements are used (have uncertainty in the measurement). 
+            The parasite measurement is compared against a threshold of zero and the gametocyte measurement a threshold
+            of 0.02.  Default is False.
+        gametocyte_detection_threshold: Used when 'use_true_density' is true.  The true gametocyte density 
+            is compared against this threshold.  It impacts the 'Pf Gametocyte Prevalence by Age Bin' channel.
         age_bins: The max age in years per bin, listed in ascending order. Use a large value for the last bin,
             to collect all remaining individuals
         infectiousness_bins: infectiousness Bins to aggregate within for the report
@@ -274,6 +286,9 @@ def add_malaria_summary_report(task, manifest,
         params.Start_Day = start_day
         params.End_Day = end_day
         params.Node_IDs_Of_Interest = node_ids if node_ids else []
+        params.Use_True_Density_Vs_Threshold = 1 if use_true_density else 0
+        if use_true_density:
+            params.Detection_Threshold_True_Gametocyte_Density = gametocyte_detection_threshold
         params.Age_Bins = age_bins if age_bins else []
         params.Must_Have_IP_Key_Value = must_have_ip_key_value
         params.Must_Have_Intervention = must_have_intervention

--- a/tests/unittests/test_malaria_reporters.py
+++ b/tests/unittests/test_malaria_reporters.py
@@ -221,6 +221,9 @@ class TestMalariaReport(unittest.TestCase):
         self.assertEqual(self.p_dict['Start_Day'], default_start_day)
         self.assertEqual(self.p_dict['Must_Have_IP_Key_Value'], empty_string)
         self.assertEqual(self.p_dict['Must_Have_Intervention'], empty_string)
+        self.assertEqual(self.p_dict['Use_True_Density_Vs_Threshold'], 0)
+        # not in the dict beccause Use_True_Density_Vs_Threshold is false
+        #self.assertEqual(self.p_dict['Detection_Threshold_True_Gametocyte_Density'], 0.0)
         pass
 
     def test_malaria_summary_report_nodelist(self):
@@ -245,6 +248,8 @@ class TestMalariaReport(unittest.TestCase):
     def test_malaria_summary_report_custom2(self):
         self.tmp_reporter = add_malaria_summary_report(None, schema_path_file,
                                                        must_have_ip_key_value="FavoriteCola:RC",
+                                                       use_true_density=True,
+                                                       gametocyte_detection_threshold=0.77,
                                                        infectiousness_bins=[-15, -5, 0, 3, 5, 8],
                                                        max_number_reports=63,
                                                        parasitemia_bins=[100, 500, 1500, 2345],
@@ -256,6 +261,8 @@ class TestMalariaReport(unittest.TestCase):
         self.assertEqual(self.p_dict['Infectiousness_Bins'], [-15, -5, 0, 3, 5, 8])
         self.assertEqual(self.p_dict['Max_Number_Reports'], 63)
         self.assertEqual(self.p_dict['Parasitemia_Bins'], [100, 500, 1500, 2345])
+        self.assertEqual(self.p_dict['Use_True_Density_Vs_Threshold'], 1)
+        self.assertEqual(self.p_dict['Detection_Threshold_True_Gametocyte_Density'], 0.77)
         pass
 
     def test_malaria_summary_report_custom3(self):


### PR DESCRIPTION
- also fixed the documentation that said the Report_Detection_Threshold_xxx was being used when it was really zero for 0.02.